### PR TITLE
[WIP] Mitigated crash if only one font format specified, CSS merge issue

### DIFF
--- a/gatsby-plugin-webfonts/src/__tests__/modules-utils-parseCss.test.js
+++ b/gatsby-plugin-webfonts/src/__tests__/modules-utils-parseCss.test.js
@@ -1,0 +1,109 @@
+import { parseCss } from "../modules/utils";
+
+const sample_google_responses = [
+  {
+    type: `single 'local()', single format`,
+    css: `@font-face {
+    font-family: 'Neucha';
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: local('Neucha'), url(https://fonts.gstatic.com/s/neucha/v10/q5uGsou0JOdh94bfvQlt.woff2) format('woff2');
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}`,
+    result: `@font-face {
+    font-family: 'Neucha';
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: local('Neucha'), url(https://fonts.gstatic.com/s/neucha/v10/q5uGsou0JOdh94bfvQlt.woff2) format('woff2');
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD
+}`,
+  },
+  {
+    type: `single 'local()', multiple formats`,
+    css: `@font-face {
+  font-family: 'Neucha';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local('Neucha'), url(https://fonts.gstatic.com/s/neucha/v10/q5uGsou0JOdh94bfvQlt.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: 'Neucha';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local('Neucha'), url(https://fonts.gstatic.com/s/neucha/v10/q5uGsou0JOdh94bfvQlr.woff) format('woff');
+}`,
+    result: `@font-face {
+    font-family: 'Neucha';
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: local('Neucha'), url(https://fonts.gstatic.com/s/neucha/v10/q5uGsou0JOdh94bfvQlt.woff2) format('woff2'),  url(https://fonts.gstatic.com/s/neucha/v10/q5uGsou0JOdh94bfvQlr.woff) format('woff');
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD
+}`,
+  },
+  {
+    type: `dual 'local()', single format`,
+    css: `@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local('Roboto'), local('Roboto-Regular'), url(https://fonts.gstatic.com/s/roboto/v19/KFOmCnqEu92Fr1Mu4mxK.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}`,
+    result: `@font-face {
+    font-family: 'Roboto';
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: local('Roboto'), local('Roboto-Regular'), url(https://fonts.gstatic.com/s/roboto/v19/KFOmCnqEu92Fr1Mu4mxK.woff2) format('woff2');
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD
+}`,
+  },
+  {
+    type: `dual 'local()', multiple formats`,
+    css: `@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local('Roboto'), local('Roboto-Regular'), url(https://fonts.gstatic.com/s/roboto/v19/KFOmCnqEu92Fr1Mu4mxK.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local('Roboto'), local('Roboto-Regular'), url(https://fonts.gstatic.com/s/roboto/v19/KFOmCnqEu92Fr1Mu4mxM.woff) format('woff');
+}`,
+    result: `@font-face {
+    font-family: 'Roboto';
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: local('Roboto'), local('Roboto-Regular'), url(https://fonts.gstatic.com/s/roboto/v19/KFOmCnqEu92Fr1Mu4mxK.woff2) format('woff2'),  url(https://fonts.gstatic.com/s/roboto/v19/KFOmCnqEu92Fr1Mu4mxM.woff) format('woff');
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD
+}`,
+  },
+];
+
+describe(`parseCss`, () => {
+  for (var i = 0; i < sample_google_responses.length; i++) {
+    it(
+      `should return correct CSS for ` + sample_google_responses[i].type,
+      (i => () => {
+        const css = parseCss(sample_google_responses[i].css, {
+          fontDisplay: `swap`,
+          useMerge: true,
+        });
+        return expect(css).resolves.toEqual(sample_google_responses[i].result);
+      })(i),
+    );
+  }
+});

--- a/gatsby-plugin-webfonts/src/__tests__/modules-utils-parseCss.test.js
+++ b/gatsby-plugin-webfonts/src/__tests__/modules-utils-parseCss.test.js
@@ -1,28 +1,32 @@
 import { parseCss } from "../modules/utils";
 
-const sample_google_responses = [
-  {
-    type: `single 'local()', single format`,
-    css: `@font-face {
-    font-family: 'Neucha';
-    font-style: normal;
-    font-weight: 400;
-    font-display: swap;
-    src: local('Neucha'), url(https://fonts.gstatic.com/s/neucha/v10/q5uGsou0JOdh94bfvQlt.woff2) format('woff2');
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}`,
-    result: `@font-face {
+describe(`parseCss`, () => {
+  it(`should return correct CSS for single 'local()', single format`, () => {
+    const google = `@font-face {
+  font-family: 'Neucha';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local('Neucha'), url(https://fonts.gstatic.com/s/neucha/v10/q5uGsou0JOdh94bfvQlt.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}`;
+    const expected = `@font-face {
     font-family: 'Neucha';
     font-style: normal;
     font-weight: 400;
     font-display: swap;
     src: local('Neucha'), url(https://fonts.gstatic.com/s/neucha/v10/q5uGsou0JOdh94bfvQlt.woff2) format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD
-}`,
-  },
-  {
-    type: `single 'local()', multiple formats`,
-    css: `@font-face {
+}`;
+    const css = parseCss(google, {
+      fontDisplay: `swap`,
+      useMerge: true,
+    });
+    return expect(css).resolves.toEqual(expected);
+  });
+
+  it(`should return correct CSS for single 'local()', multiple formats`, () => {
+    const google = `@font-face {
   font-family: 'Neucha';
   font-style: normal;
   font-weight: 400;
@@ -36,38 +40,48 @@ const sample_google_responses = [
   font-weight: 400;
   font-display: swap;
   src: local('Neucha'), url(https://fonts.gstatic.com/s/neucha/v10/q5uGsou0JOdh94bfvQlr.woff) format('woff');
-}`,
-    result: `@font-face {
+}`;
+    const expected = `@font-face {
     font-family: 'Neucha';
     font-style: normal;
     font-weight: 400;
     font-display: swap;
     src: local('Neucha'), url(https://fonts.gstatic.com/s/neucha/v10/q5uGsou0JOdh94bfvQlt.woff2) format('woff2'),  url(https://fonts.gstatic.com/s/neucha/v10/q5uGsou0JOdh94bfvQlr.woff) format('woff');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD
-}`,
-  },
-  {
-    type: `dual 'local()', single format`,
-    css: `@font-face {
+}`;
+    const css = parseCss(google, {
+      fontDisplay: `swap`,
+      useMerge: true,
+    });
+    return expect(css).resolves.toEqual(expected);
+  });
+
+  it(`should return correct CSS for dual 'local()', single format`, () => {
+    const google = `@font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
   font-display: swap;
   src: local('Roboto'), local('Roboto-Regular'), url(https://fonts.gstatic.com/s/roboto/v19/KFOmCnqEu92Fr1Mu4mxK.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}`,
-    result: `@font-face {
+}`;
+    const expected = `@font-face {
     font-family: 'Roboto';
     font-style: normal;
     font-weight: 400;
     font-display: swap;
     src: local('Roboto'), local('Roboto-Regular'), url(https://fonts.gstatic.com/s/roboto/v19/KFOmCnqEu92Fr1Mu4mxK.woff2) format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD
-}`,
-  },
-  {
-    type: `dual 'local()', multiple formats`,
-    css: `@font-face {
+}`;
+    const css = parseCss(google, {
+      fontDisplay: `swap`,
+      useMerge: true,
+    });
+    return expect(css).resolves.toEqual(expected);
+  });
+
+  it(`should return correct CSS for dual 'local()', multiple formats`, () => {
+    const google = `@font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
@@ -81,29 +95,19 @@ const sample_google_responses = [
   font-weight: 400;
   font-display: swap;
   src: local('Roboto'), local('Roboto-Regular'), url(https://fonts.gstatic.com/s/roboto/v19/KFOmCnqEu92Fr1Mu4mxM.woff) format('woff');
-}`,
-    result: `@font-face {
+}`;
+    const expected = `@font-face {
     font-family: 'Roboto';
     font-style: normal;
     font-weight: 400;
     font-display: swap;
     src: local('Roboto'), local('Roboto-Regular'), url(https://fonts.gstatic.com/s/roboto/v19/KFOmCnqEu92Fr1Mu4mxK.woff2) format('woff2'),  url(https://fonts.gstatic.com/s/roboto/v19/KFOmCnqEu92Fr1Mu4mxM.woff) format('woff');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD
-}`,
-  },
-];
-
-describe(`parseCss`, () => {
-  for (var i = 0; i < sample_google_responses.length; i++) {
-    it(
-      `should return correct CSS for ` + sample_google_responses[i].type,
-      (i => () => {
-        const css = parseCss(sample_google_responses[i].css, {
-          fontDisplay: `swap`,
-          useMerge: true,
-        });
-        return expect(css).resolves.toEqual(sample_google_responses[i].result);
-      })(i),
-    );
-  }
+}`;
+    const css = parseCss(google, {
+      fontDisplay: `swap`,
+      useMerge: true,
+    });
+    return expect(css).resolves.toEqual(expected);
+  });
 });

--- a/gatsby-plugin-webfonts/src/modules/utils.js
+++ b/gatsby-plugin-webfonts/src/modules/utils.js
@@ -17,7 +17,7 @@ function fontFaceReducer(fontDisplay = `swap`, useMerge) {
       if (index > -1) {
         // we don't know how many 'local'-names the font might have, so we
         // just use the last entry, which should be the 'url' entry of the
-        // requested type 
+        // requested type.
         acc[index].src = `${acc[index].src}, ${srcs[srcs.length - 1]}`;
         return acc;
       }
@@ -26,7 +26,7 @@ function fontFaceReducer(fontDisplay = `swap`, useMerge) {
     obj.fontDisplay = fontDisplay;
     acc.push(obj);
     return acc;
-  }
+  };
 }
 
 export async function parseCss(cssString, { fontDisplay = `swap`, useMerge }) {
@@ -36,8 +36,9 @@ export async function parseCss(cssString, { fontDisplay = `swap`, useMerge }) {
 
   if (cssObject[`@font-face`]) {
     const reducer = fontFaceReducer(fontDisplay, useMerge);
-    cssObject[`@font-face`] = Array.isArray(cssObject[`@font-face`]) ? 
-      cssObject[`@font-face`].reduce(reducer, []) : reducer([], cssObject[`@font-face`]);
+    cssObject[`@font-face`] = Array.isArray(cssObject[`@font-face`])
+      ? cssObject[`@font-face`].reduce(reducer, [])
+      : reducer([], cssObject[`@font-face`]);
   }
 
   const { css } = await postcss().process(cssObject, {

--- a/gatsby-plugin-webfonts/src/modules/utils.js
+++ b/gatsby-plugin-webfonts/src/modules/utils.js
@@ -5,30 +5,39 @@ import axios from "axios";
 import postcss from "postcss";
 import postcssJs from "postcss-js";
 
+function fontFaceReducer(fontDisplay = `swap`, useMerge) {
+  return (acc, obj) => {
+    if (useMerge) {
+      const srcs = obj.src.split(`,`);
+
+      const index = acc.findIndex(element => {
+        return element.src.split(`,`)[0] === srcs[0];
+      });
+
+      if (index > -1) {
+        // we don't know how many 'local'-names the font might have, so we
+        // just use the last entry, which should be the 'url' entry of the
+        // requested type 
+        acc[index].src = `${acc[index].src}, ${srcs[srcs.length - 1]}`;
+        return acc;
+      }
+    }
+
+    obj.fontDisplay = fontDisplay;
+    acc.push(obj);
+    return acc;
+  }
+}
+
 export async function parseCss(cssString, { fontDisplay = `swap`, useMerge }) {
   const root = postcss.parse(cssString);
 
   const cssObject = postcssJs.objectify(root);
 
   if (cssObject[`@font-face`]) {
-    cssObject[`@font-face`] = cssObject[`@font-face`].reduce((acc, obj) => {
-      if (useMerge) {
-        const srcs = obj.src.split(`,`);
-
-        const index = acc.findIndex(element => {
-          return element.src.split(`,`)[0] === srcs[0];
-        });
-
-        if (index > -1) {
-          acc[index].src = `${acc[index].src}, ${srcs[2]}`;
-          return acc;
-        }
-      }
-
-      obj.fontDisplay = fontDisplay;
-      acc.push(obj);
-      return acc;
-    }, []);
+    const reducer = fontFaceReducer(fontDisplay, useMerge);
+    cssObject[`@font-face`] = Array.isArray(cssObject[`@font-face`]) ? 
+      cssObject[`@font-face`].reduce(reducer, []) : reducer([], cssObject[`@font-face`]);
   }
 
   const { css } = await postcss().process(cssObject, {


### PR DESCRIPTION
If the user specified only one font format (e.g. `formats: ['woff2'],`), postcssJs creates only a single object, not a list of objects - the `.reduce()` call fails.

I've pulled the reducer function out of parseCSS and check whether it's an array or not and call `reduce()` or the reducer accordingly.

Also corrected CSS generation issue if CSS downloaded from Google Fonts only contains one `local()` definition (or more than two).  E.g. the font "Neucha" only sports one, which resulted in `srcs[2]` being undefined. So "undefined" ended up in the CSS which the browser doesn't understand and the font's whole definition is ignored.

Instead, I'm assuming the last srcs-entry (`srcs[srcs.length - 1]`) to always be the correct url() entry (this might not work/being incomplete if Google suddenly send two or more url() alternatives).