### PR TITLE
fix plugin

### DIFF
--- a/gatsby-plugin-webfonts/.npmignore
+++ b/gatsby-plugin-webfonts/.npmignore
@@ -1,3 +1,4 @@
+.babelrc
 # Logs
 logs
 *.log


### PR DESCRIPTION
gatsby now compiles packages with gatsby in the name, so it sees this with a babelrc and trys to compile it unnecessarily