### PR TITLE
Add support for Google Fonts API v2

### DIFF
--- a/gatsby-plugin-webfonts/README.md
+++ b/gatsby-plugin-webfonts/README.md
@@ -136,6 +136,58 @@ module.exports = {
 
 The text subsetting functionality is only available for Google fonts.
 
+### Google Fonts v2
+
+> This is an extension of the "Google Fonts" setting which uses the latest API.
+
+You can also use the latest [Google Fonts API v2](https://developers.google.com/fonts/docs/css2).
+
+Use the `axes` option like so:
+
+```javascript
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-plugin-webfonts`,
+      options: {
+        fonts: {
+          google2: [
+            {
+              family: "Roboto",
+              axes: "wght@300;400;500",
+            },
+          ],
+        },
+      },
+    },
+  ],
+};
+```
+
+A [variable font](https://web.dev/variable-fonts/) packs all the styles and weights of a font family into a single file.
+
+Only a few Google Fonts are available as [variable fonts](https://fonts.google.com/variablefonts).
+Some have their own custom axes that can be set accordingly.
+
+```javascript
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-plugin-webfonts`,
+      options: {
+        fonts: {
+          google2: [
+            {
+              family: "Rubik",
+              axes: "wght@300..600", // multiple ranges are supported, ex: "wght@300..500;700..900"
+            },
+          ],
+        },
+      },
+    },
+  ],
+};
+```
 
 ## License
 

--- a/gatsby-plugin-webfonts/src/modules/google.js
+++ b/gatsby-plugin-webfonts/src/modules/google.js
@@ -7,18 +7,16 @@ const defaultFontOptions = {
   strategy: `selfHosted`, //'base64' || 'cdn'
 };
 
-export default function google({
-  cacheFolder,
-  pathPrefix,
-  formats,
-  formatAgents,
-}) {
+export default function google(
+  { cacheFolder, pathPrefix, formats, formatAgents },
+  version,
+) {
   return (fonts) =>
     Promise.all(
       fonts.map(async (font) => {
         const { fontDisplay, strategy } = createFontOptions(font);
 
-        const requestUrl = createRequestUrl(font);
+        const requestUrl = createRequestUrl(font, version);
 
         const cssStrings = await Promise.all(
           formats.map(async (format) => {
@@ -56,13 +54,30 @@ export function isGooglePreconnectEnabled(options) {
   );
 }
 
-export function createRequestUrl(font) {
+export function createRequestUrl(font, version) {
   if (!font.family) return null;
 
-  let requestUrl = `${API_URL}?family=${font.family.replace(/ /g, `+`)}`;
+  let requestUrl = API_URL;
 
-  if (font.variants) {
-    requestUrl += `:${font.variants.join(`,`)}`;
+  if (version === 2) {
+    requestUrl += `2`;
+  }
+
+  requestUrl += `?family=${font.family.replace(/ /g, `+`)}`;
+
+  switch (version) {
+    case 1:
+      if (font.variatns) {
+        requestUrl += `:${font.variants.join(`,`)}`;
+      }
+      break;
+    case 2:
+      if (font.axes) {
+        requestUrl += `:${font.axes}`;
+      }
+      break;
+    default:
+      return null;
   }
 
   if (font.subsets) {

--- a/gatsby-plugin-webfonts/src/modules/google.js
+++ b/gatsby-plugin-webfonts/src/modules/google.js
@@ -67,7 +67,7 @@ export function createRequestUrl(font, version) {
 
   switch (version) {
     case 1:
-      if (font.variatns) {
+      if (font.variants) {
         requestUrl += `:${font.variants.join(`,`)}`;
       }
       break;

--- a/gatsby-plugin-webfonts/src/web-fonts.js
+++ b/gatsby-plugin-webfonts/src/web-fonts.js
@@ -7,7 +7,8 @@ import google from "./modules/google";
 
 export default async function webFonts(options) {
   const modules = {
-    google: google(options),
+    google: google(options, 1),
+    google2: google(options, 2),
   };
 
   const merge = async (css) => {


### PR DESCRIPTION
## Overview

This pull request adds support for [Google Fonts API v2](https://developers.google.com/fonts/docs/css2).

## Features

The new `google2` module supports the latest Google Fonts API.

### `axes`

The update introduces a new `axes` option to set [axis ranges](https://developers.google.com/fonts/docs/css2#axis_ranges).

#### `font-weight`

_Roboto [700]_

```diff
-  google: {
+  google2: {
    family: "Roboto",
-    variants: ["700"],
+    axes: "wght@700",
  }
```

<details>
<summary>CSS</summary>

```css
@font-face {
  font-family: "Roboto";
  font-style: normal;
  font-weight: 300;
  src: url(https://fonts.gstatic.com/path/to/font) format("woff2"); /* subject to change */
}
```

</details>

_Nunito [300, 400 & 600]_

```diff
-  google: {
+  google2: {
    family: "Nunito",
-    variants: ["300", "400", "600"],
+    axes: "wght@300;400;600",
  }
```

<details>
<summary>CSS</summary>

```css
@font-face {
  font-family: "Nunito";
  font-style: normal;
  font-weight: 300;
  src: url(https://fonts.gstatic.com/path/to/font) format("woff2"); /* subject to change */
}
@font-face {
  font-family: "Nunito";
  font-style: normal;
  font-weight: 400;
  src: url(https://fonts.gstatic.com/path/to/font) format("woff2"); /* subject to change */
}
@font-face {
  font-family: "Nunito";
  font-style: normal;
  font-weight: 600;
  src: url(https://fonts.gstatic.com/path/to/font) format("woff2"); /* subject to change */
}
```

</details>

#### `font-style`

_Open Sans [400 Italic]_

```diff
-  google: {
+  google2: {
    family: "Open Sans",
-    variants: ["italic"],
+    axes: "ital@1",
  }
```

<details>
<summary>CSS</summary>

```css
@font-face {
  font-family: "Open Sans";
  font-style: italic;
  font-weight: 400;
  src: url(https://fonts.gstatic.com/path/to/font) format("woff2"); /* subject to change */
}
```

</details>

### Variable Fonts

> A [variable font](https://web.dev/variable-fonts/) packs all the styles and weights of a font family into a single file.

Only a few Google Fonts are available as [variable fonts](https://fonts.google.com/variablefonts).
Some have their own custom axes that can be set accordingly.

_Rubik [300 to 600]_

```javascript
module.exports = {
  plugins: [
    {
      resolve: `gatsby-plugin-webfonts`,
      options: {
        fonts: {
          google2: [
            {
              family: "Rubik",
              axes: "wght@300..600", // multiple ranges are supported, ex: "wght@300..500;700..900"
            },
          ],
        },
      },
    },
  ],
};
```

<details>
<summary>CSS</summary>

```css
@font-face {
  font-family: "Rubik";
  font-style: normal;
  font-weight: 300 600;
  src: url(https://fonts.gstatic.com/path/to/font) format("woff2"); /* subject to change */
}
```

</details>

## Notes

In this section, I will summarize the changes done to the codebase.

- `feat: Add support for Google Fonts v2 API` (f48df57)

  Added a `version` argument to the `google` & `createRequestUrl` functions of the `google` module.
  This preserves the original API and provides support for the new one.

  Another module, `google2` was added in `web-fonts.js`.

- `docs: Update README with Google Fonts v2` (994ee1f)

  - An example for migrating to the new API was added.
  - An example using variable fonts was added.

> Tests using variable fonts could be checked, but might not be necessary.

Thank you for your time!
Any suggestions are appreciated!
